### PR TITLE
Update to v0.18.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.4.5 AS monero-wallet-rpc
-FROM ghcr.io/sethforprivacy/simple-monerod:v0.18.4.5
+FROM ghcr.io/sethforprivacy/simple-monero-wallet-rpc:v0.18.5.0 AS monero-wallet-rpc
+FROM ghcr.io/sethforprivacy/simple-monerod:v0.18.5.0
 COPY --from=monero-wallet-rpc "/usr/local/bin/monero-wallet-rpc" /usr/local/bin/
 
 USER root

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,10 +1,9 @@
 id: monerod
 title: "Monero"
-version: 0.18.4.5
+version: 0.18.5.0
 release-notes: |
   * Update to latest upstream [sethforprivacy Monero docker image](https://github.com/sethforprivacy/simple-monerod-docker)
-  * Includes Monero 0.18.4.5 ([Release Notes](https://www.getmonero.org/2026/01/11/monero-0.18.4.5-released.html))
-  * Exposed Unrestricted RPC to other StartOS service containers
+  * Includes Monero 0.18.5.0 ([Release Notes](https://www.getmonero.org/2026/05/11/monero-0.18.5.0-released.html))
 license: BSD-3
 wrapper-repo: https://github.com/kn0wmad/monerod-startos
 upstream-repo: https://github.com/monero-project/monero

--- a/scripts/services/migrations.ts
+++ b/scripts/services/migrations.ts
@@ -45,6 +45,6 @@ export const migration: T.ExpectedExports.migration = async (
         ),
       },
     },
-    "0.18.4.5"
+    "0.18.5.0"
   )(effects, version, ...args);
 };


### PR DESCRIPTION
* Update to latest upstream sethforprivacy Monero docker image
* Includes Monero 0.18.5.0 (Fluorine Fermi, Major Point Release 5)
* Release notes: https://www.getmonero.org/2026/05/11/monero-0.18.5.0-released.html